### PR TITLE
Minor simplifications

### DIFF
--- a/extra/in_place_expr_validity/2_cpp17.cpp
+++ b/extra/in_place_expr_validity/2_cpp17.cpp
@@ -8,17 +8,17 @@
 template <typename... Ts, typename TF>
 static constexpr auto is_valid(TF)
 {
-    return std::is_callable<std::decay_t<TF>(Ts...)>{};
+    return std::is_invocable<TF, Ts...>{};
 }
 
 #define IS_VALID_EXPANDER_BEGIN(count)                    \
     [](VRM_PP_REPEAT_INC(count, IS_VALID_EXPANDER_MIDDLE, \
-        _)) constexpr->decltype IS_VALID_EXPANDER_END
+        _)) constexpr IS_VALID_EXPANDER_END
 
 #define IS_VALID_EXPANDER_MIDDLE(idx, _) VRM_PP_COMMA_IF(idx) auto _##idx
 
 #define IS_VALID_EXPANDER_END(...) \
-    (__VA_ARGS__){})
+    -> decltype(void(__VA_ARGS__)){})
 
 #define IS_VALID(...)                              \
     is_valid<__VA_ARGS__>(IS_VALID_EXPANDER_BEGIN( \


### PR DESCRIPTION
`is_callable` was never standardized; the standard thing is `is_invocable`.
Also, using `is_invocable<TF, Ts...>` instead of `is_callable<TF(Ts...)>`
means that it'll work correctly (instead of erroring out) even when `TF`
is a type that can't be returned from a function, such as `int[]`.

`decay_t<TF>` is the same as `TF`, since `TF` is a function parameter type
passed by value which was deduced.

`decltype(expr)` should really probably be `decltype(void(expr))`
or equivalently `decltype(expr, void())` just in case `expr` has a type
that can't be returned from a function, such as `int[]`. Test case:

    struct S { int a[2]; }
    static_assert(IS_VALID(S)(_0.a));

Move `->decltype` from IS_VALID_EXPANDER_BEGIN to IS_VALID_EXPANDER_END
for aesthetics.